### PR TITLE
Prevent ghosting when typing conflicting characters

### DIFF
--- a/keyboards/sculpter/config.h
+++ b/keyboards/sculpter/config.h
@@ -23,8 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define VENDOR_ID    0xFEED
 #define PRODUCT_ID   0x0000
 #define DEVICE_VER   0x0001
-#define MANUFACTURER Chris Paynter
-#define PRODUCT      sculpter
+#define MANUFACTURER Isaac
+#define PRODUCT      sculpt-wired
 
 /* key matrix size */
 #define MATRIX_ROWS 8
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 #define MATRIX_ROW_PINS { C7, C6, D3, D2, D1, D0, B7, B3 }
-#define MATRIX_COL_PINS { B2, B1, B0, E6, D5, D4, D6, D7, B4, B5, B6, F7, F6, F5, F4, F1, F0 }
+#define MATRIX_COL_PINS { B6, B1, B0, E6, D5, D4, D6, D7, B4, B5, B2, F7, F6, F5, F4, F1, F0 }
 #define UNUSED_PINS
 
 /* COL2ROW, ROW2COL */
@@ -92,6 +92,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
+
 
 /* define if matrix has ghost (lacks anti-ghosting diodes) */
 #define MATRIX_HAS_GHOST

--- a/keyboards/sculpter/config.h
+++ b/keyboards/sculpter/config.h
@@ -94,7 +94,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEBOUNCE 5
 
 /* define if matrix has ghost (lacks anti-ghosting diodes) */
-//#define MATRIX_HAS_GHOST
+#define MATRIX_HAS_GHOST
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE


### PR DESCRIPTION
Define MATRIX_HAS_GHOST to eliminate ghost keypresses

## Description

Define flag to add anti ghosting support - Without this, pressing the <SPACE>, E, and R keys at the same time results in a ghost keypress of "b" - this is due to the lack of diodes on the keyboard. Mods involving the keyboard should enable the flag to have QMK handle anti-ghosting support
